### PR TITLE
Add check for Bulk Action plugin and dependency note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ### Dependencies
 
 - npm: gulp, gulp-stylus, autoprefixer-stylus
+- WP Plugins: Custom Bulk Action plugin by Seravo
 
 ### Gulp tasks
 

--- a/functions.php
+++ b/functions.php
@@ -61,4 +61,13 @@ if (class_exists('Seravo_Custom_Bulk_Action')) {
   ));
 
   $bulk_action->init();
+} else {
+  function bulk_action_dependency_notice() {
+      ?>
+      <div class="error notice">
+          <p><?php _e( 'This plugin requires the <a href="https://wordpress.org/plugins/custom-bulk-actions/" target="_blank"> Seravo Custom Bulk Action</a> plugin to function properly.', 'prosody_textdomain' ); ?></p>
+      </div>
+      <?php
+  }
+  add_action( 'admin_notices', 'bulk_action_dependency_notice' );
 }

--- a/functions.php
+++ b/functions.php
@@ -44,20 +44,21 @@ add_action('wp_dashboard_setup', 'prosody_direction_widget');
 remove_filter('the_content', 'wpautop');
 
 // Code for adding bulk action to process metadata
+if (class_exists('Seravo_Custom_Bulk_Action')) {
+  $bulk_action = new Seravo_Custom_Bulk_Action(array('post_type' => 'prosody_poem'));
 
-$bulk_action = new Seravo_Custom_Bulk_Action(array('post_type' => 'prosody_poem'));
-
-$bulk_action->register_bulk_action(array(
-  'menu_text' => 'Update Posts',
-  'admin_notice' => 'Posts Updated',
-  'callback' => function($post_ids) {
-      foreach ($post_ids as $post_id) {
-        global $post;
-        $post = get_post($post_id);
-        prosody_xml_transform($post);
+  $bulk_action->register_bulk_action(array(
+    'menu_text' => 'Update Posts',
+    'admin_notice' => 'Posts Updated',
+    'callback' => function($post_ids) {
+        foreach ($post_ids as $post_id) {
+          global $post;
+          $post = get_post($post_id);
+          prosody_xml_transform($post);
+        }
+        return true;
       }
-      return true;
-    }
-));
+  ));
 
-$bulk_action->init();
+  $bulk_action->init();
+}


### PR DESCRIPTION
I added a `class_exist` call to the functions.php file so that the site wouldn't crash without the Sevaro Custom Bulk Action plugin.

I also added a note in the README about the WP Plugin dependency.

Resolves issue #12 