### PR TITLE
Add color style for meter select dropdown

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -468,6 +468,9 @@ footer .scholars_lab_logo img {
   font-size: 1.8em;
   margin-bottom: 20px;
 }
+#meter-select select {
+  color: #000;
+}
 #meter-select option {
   color: #000;
 }

--- a/css/screen.styl
+++ b/css/screen.styl
@@ -493,7 +493,8 @@ footer
 
 // Styles for check meter popup box
 #meter-select
-  // color white
+  select
+    color black
 
   option
     color black


### PR DESCRIPTION
I added a color style to the stylus and compiled the compiled the css, as per issue #7 

I used the black color since that is the same color it was anyway -- so the issue should be resolved without there being any changes to the actual site experience.