### PR TITLE
JS linting

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,6 +18,12 @@ gulp.task('lint', function() {
 	.pipe(jshint.reporter('default'))
 });
 
+gulp.task('plugin_lint', function() {
+	return gulp.src('../../plugins/prosody_plugin/js/handlers.js')
+	.pipe(jshint())
+	.pipe(jshint.reporter('default'))
+});
+
 gulp.task('watch', function() {
     gulp.watch('**/*.styl', ['stylus']);
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,13 +14,20 @@ gulp.task('stylus', function() {
 
 gulp.task('lint', function() {
 	return gulp.src('./js/utility.js')
-	.pipe(jshint())
+	.pipe(jshint({'eqeqeq': true}))
 	.pipe(jshint.reporter('default'))
 });
 
 gulp.task('plugin_lint', function() {
 	return gulp.src('../../plugins/prosody_plugin/js/handlers.js')
-	.pipe(jshint())
+	.pipe(jshint(
+        {
+            'eqeqeq': true,
+            'latedef': 'nofunc',
+            'shadow': false,
+            'undef': true
+        }
+    ))
 	.pipe(jshint.reporter('default'))
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,7 @@
 var gulp = require('gulp'),
-      stylus = require('gulp-stylus'),
-      autoprefixer = require('autoprefixer-stylus');
+    stylus = require('gulp-stylus'),
+    autoprefixer = require('autoprefixer-stylus'),
+    jshint = require('gulp-jshint');
 
 
 gulp.task('stylus', function() {
@@ -9,6 +10,12 @@ gulp.task('stylus', function() {
         use: [autoprefixer()]
     }))
     .pipe(gulp.dest('css/'));
+});
+
+gulp.task('lint', function() {
+	return gulp.src('./js/utility.js')
+	.pipe(jshint())
+	.pipe(jshint.reporter('default'))
 });
 
 gulp.task('watch', function() {

--- a/package.json
+++ b/package.json
@@ -10,5 +10,9 @@
     "gulp-stylus": "^2.0.1",
     "html5shiv": "^3.7.2",
     "normalize.css": "^3.0.3"
+  },
+  "devDependencies": {
+    "gulp-jshint": "^2.0.4",
+    "jshint": "^2.9.5"
   }
 }


### PR DESCRIPTION
Added basic linting with `jshint`

To install, run `npm install` and run them with `gulp lint` and `gulp plugin_lint`

Clearly it would be better to have the plugin lint in the same repo as the plugin itself, but I decided not to add a separate gulp file before we had a chance to discuss how / if to actually reorganize the folders / repos / etc.

More specific lint settings should be added eventually too.